### PR TITLE
fix(evm): correct searchEvents abi parameter type to array

### DIFF
--- a/reference/arbitrum.yaml
+++ b/reference/arbitrum.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: arbitrum
-  version: 0.2.21
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10866,13 +10866,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/arc.yaml
+++ b/reference/arc.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: arc
-  version: 1.2.26
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -11094,13 +11094,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/base.yaml
+++ b/reference/base.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: base
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10866,13 +10866,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/bnb.yaml
+++ b/reference/bnb.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: bnb
-  version: 1.2.22
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10857,13 +10857,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/chiliz.yaml
+++ b/reference/chiliz.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: chiliz
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10830,13 +10830,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/ethereum.yaml
+++ b/reference/ethereum.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ethereum
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10902,13 +10902,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/ethereumclassic.yaml
+++ b/reference/ethereumclassic.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ethereumclassic
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10296,13 +10296,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/giwa.yaml
+++ b/reference/giwa.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: giwa
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10830,13 +10830,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/kaia.yaml
+++ b/reference/kaia.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: kaia
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -7895,8 +7895,7 @@ paths:
                                 블록이 생성된 시간을 나타내는 필드입니다.
 
 
-                                마이크로초(microseconds) 단위의 UNIX 타임스탬프로 제공되며, 블록의 생성
-                                순서와 시간 추적에 사용됩니다.
+                                UNIX 타임스탬프로 제공되며, 블록의 생성 순서와 시간 추적에 사용됩니다.
 
                                 블록 타임스탬프는 트랜잭션의 시간 순서를 보장하고 블록 생성 간격을 측정하는 데
                                 활용됩니다.
@@ -11748,13 +11747,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/luniverse.yaml
+++ b/reference/luniverse.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: luniverse
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10830,13 +10830,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/optimism.yaml
+++ b/reference/optimism.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: optimism
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10899,13 +10899,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/polygon.yaml
+++ b/reference/polygon.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: polygon
-  version: 1.2.20
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -10866,13 +10866,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/reference/web3-data-api.yaml
+++ b/reference/web3-data-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Web3 Data API
-  version: 1.2.26
+  version: main
 servers:
   - url: https://web3.nodit.io/v1
 components:
@@ -25342,13 +25342,35 @@ paths:
                       default:
                         - Transfer
                     abi:
-                      type: string
-                      format: json
+                      type: array
+                      items:
+                        type: object
+                        additionalProperties: true
                       description: >-
-                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할
-                        수 있습니다.
-                      default: >-
-                        [{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]
+                        조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로
+                        입력합니다 (문자열로 stringify하지 않습니다).
+                      default:
+                        - anonymous: false
+                          inputs:
+                            - indexed: true
+                              name: from
+                              type: address
+                            - indexed: true
+                              name: to
+                              type: address
+                            - indexed: false
+                              name: value
+                              type: uint256
+                          name: Transfer
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Pause
+                          type: event
+                        - anonymous: false
+                          inputs: []
+                          name: Unpause
+                          type: event
                     fromBlock: *ref_14
                     toBlock: *ref_15
                     fromDate: *ref_16

--- a/src/categories/web3-data-api/library/requests/ethereum.requests.ts
+++ b/src/categories/web3-data-api/library/requests/ethereum.requests.ts
@@ -59,9 +59,12 @@ export const eventNames: OpenAPIV3.SchemaObject = {
 };
 
 export const abi: OpenAPIV3.SchemaObject = {
-	type: "string",
-	format: "json",
-	description: "조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. JSON 형태의 ABI 문자열을 입력할 수 있습니다.",
+	type: "array",
+	items: {
+		type: "object",
+		additionalProperties: true,
+	},
+	description: "조회하고자 하는 컨트랙트의 ABI를 지정하는 파라미터입니다. ABI JSON 배열 자체를 그대로 입력합니다 (문자열로 stringify하지 않습니다).",
 };
 
 /* Range */

--- a/src/constants/ethereum.constants.ts
+++ b/src/constants/ethereum.constants.ts
@@ -1,7 +1,20 @@
 export const ERC20 = {
 	USDT: {
 		CONTRACT_ADDRESS: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-		ABI: `[{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"}]`,
+		ABI: [
+			{
+				anonymous: false,
+				inputs: [
+					{ indexed: true, name: "from", type: "address" },
+					{ indexed: true, name: "to", type: "address" },
+					{ indexed: false, name: "value", type: "uint256" },
+				],
+				name: "Transfer",
+				type: "event",
+			},
+			{ anonymous: false, inputs: [], name: "Pause", type: "event" },
+			{ anonymous: false, inputs: [], name: "Unpause", type: "event" },
+		],
 	},
 	USDC: {
 		CONTRACT_ADDRESS: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",


### PR DESCRIPTION
## Summary
- `searchEvents` API의 `abi` 파라미터가 stringified JSON 문자열이 아닌 JSON 배열 자체로 입력되어야 실제 API가 동작하므로, 스펙을 `type: array, items: { type: object }`로 변경
- `ERC20.USDT.ABI` default 값을 stringified 문자열에서 객체 배열로 교체
- EVM 계열 14개 reference yaml(ethereum, polygon, optimism, arbitrum, base, bnb, chiliz, kaia, giwa, luniverse, ethereumclassic, arc, web3-data-api) 일괄 재생성

## Test plan
- [x] 갱신된 reference yaml의 `searchEvents` 요청 스키마가 `type: array` + 객체 배열 default로 렌더링되는지 확인
- [x] Nodit MCP / 실제 API로 ABI 객체 배열을 그대로 보내 정상 응답이 오는지 end-to-end 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)