### PR TITLE
chore: switch sync script to HTTPS clone

### DIFF
--- a/scripts/sync-reference.sh
+++ b/scripts/sync-reference.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_REPO="git@github.com:Lambda256/nodit-docs-migration.git"
+SOURCE_REPO="https://github.com/Lambda256/nodit-docs-migration.git"
 SOURCE_BRANCH="main"
 SOURCE_PATH="oas/dist-en"
 TARGET_DIR="reference"


### PR DESCRIPTION
## Summary
- `scripts/sync-reference.sh` now clones the source repo over HTTPS instead of SSH so it works without an SSH key registered on Lambda256.
- Authentication is delegated to the `gh` credential helper (`gh auth setup-git`).

## Test plan
- [ ] Merge this PR
- [ ] Pull main locally
- [ ] Run `./scripts/sync-reference.sh` and confirm it either opens a sync PR or exits with "No changes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)